### PR TITLE
add named export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,1 @@
-declare module 'klona' {
-	function klona<T>(val: T): T;
-	export = klona;
-}
+export function klona<T>(input: T): T;

--- a/klona.d.ts
+++ b/klona.d.ts
@@ -1,1 +1,0 @@
-export function klona<T>(val: T): T

--- a/klona.d.ts
+++ b/klona.d.ts
@@ -1,1 +1,3 @@
-export default function<T>(val: T): T;
+declare function klona<T>(val: T): T
+export default klona;
+export { klona };

--- a/klona.d.ts
+++ b/klona.d.ts
@@ -1,3 +1,1 @@
-declare function klona<T>(val: T): T
-export default klona;
-export { klona };
+export function klona<T>(val: T): T

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function klona(x) {
+function klona(x) {
 	if (typeof x !== 'object') return x;
 
 	var k, tmp, str=Object.prototype.toString.call(x);
@@ -60,3 +60,6 @@ export default function klona(x) {
 
 	return x;
 }
+
+export default klona;
+export { klona };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-function klona(x) {
+export function klona(x) {
 	if (typeof x !== 'object') return x;
 
 	var k, tmp, str=Object.prototype.toString.call(x);
@@ -60,6 +60,3 @@ function klona(x) {
 
 	return x;
 }
-
-export default klona;
-export { klona };


### PR DESCRIPTION
This duplicates the default export as a named export.

## Why?

It is currently impossible to use this in a TypeScript module that compiles to both CJS and ESM targets from the same source code. This is because of the way default imports are handled.

In a CJS target, only this works (and has the TypeScript compiler complain):
```ts
import * as klona from 'klona';
```

Whereas in an MJS target, only this works:
```ts
import klona from 'klona';
```

The respective other one will fail at runtime.

With this PR, this will work for both targets:
```ts
import { klona } from 'klona';
```

The default export is kept for backwards compatibility, although I'd advise to get rid of it in a future major update.

Please note that your build system currently doesn't seem to support this, as building the output files failed for me. I have sent the PR lukeed/bundt#3 to fix this. The future update to that package will need to be incorporated into this PR as well.