### PR TITLE
Fixed class Object assign.

### DIFF
--- a/src/full.js
+++ b/src/full.js
@@ -8,7 +8,7 @@ function set(obj, key, val) {
 export function klona(x) {
 	if (typeof x !== 'object') return x;
 
-	var i=0, k, list, tmp, str=Object.prototype.toString.call(x);
+	var i = 0, k, list, tmp, str = Object.prototype.toString.call(x);
 
 	if (str === '[object Object]') {
 		tmp = Object.create(x.__proto__ || null);
@@ -29,7 +29,7 @@ export function klona(x) {
 	} else if (str === '[object RegExp]') {
 		tmp = new RegExp(x.source, x.flags);
 	} else if (str === '[object DataView]') {
-		tmp = new x.constructor( klona(x.buffer) );
+		tmp = new x.constructor(klona(x.buffer));
 	} else if (str === '[object ArrayBuffer]') {
 		tmp = x.slice(0);
 	} else if (str.slice(-6) === 'Array]') {
@@ -39,12 +39,12 @@ export function klona(x) {
 	}
 
 	if (tmp) {
-		for (list=Object.getOwnPropertySymbols(x); i < list.length; i++) {
+		for (list = Object.getOwnPropertySymbols(x); i < list.length; i++) {
 			set(tmp, list[i], Object.getOwnPropertyDescriptor(x, list[i]));
 		}
 
-		for (i=0, list=Object.getOwnPropertyNames(x); i < list.length; i++) {
-			if (Object.hasOwnProperty.call(tmp, k=list[i]) && tmp[k] === x[k]) continue;
+		for (i = 0, list = Object.getOwnPropertyNames(x); i < list.length; i++) {
+			if (Object.hasOwnProperty.call(tmp, k = list[i]) && tmp[k] === x[k]) continue;
 			set(tmp, k, Object.getOwnPropertyDescriptor(x, k));
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 export function klona(x) {
 	if (typeof x !== 'object') return x;
 
-	var k, tmp, str=Object.prototype.toString.call(x);
+	var k, tmp, str = Object.prototype.toString.call(x);
 
 	if (str === '[object Object]') {
 		if (x.constructor !== Object && typeof x.constructor === 'function') {
 			tmp = new x.constructor();
 			for (k in x) {
-				if (tmp.hasOwnProperty(k) && tmp[k] !== x[k]) {
+				if (tmp[k] !== x[k]) {
 					tmp[k] = klona(x[k]);
 				}
 			}
@@ -31,7 +31,7 @@ export function klona(x) {
 
 	if (str === '[object Array]') {
 		k = x.length;
-		for (tmp=Array(k); k--;) {
+		for (tmp = Array(k); k--;) {
 			tmp[k] = klona(x[k]);
 		}
 		return tmp;
@@ -64,7 +64,7 @@ export function klona(x) {
 	}
 
 	if (str === '[object DataView]') {
-		return new x.constructor( klona(x.buffer) );
+		return new x.constructor(klona(x.buffer));
 	}
 
 	if (str === '[object ArrayBuffer]') {

--- a/src/json.js
+++ b/src/json.js
@@ -2,8 +2,8 @@ export function klona(val) {
 	var k, out, tmp;
 
 	if (Array.isArray(val)) {
-		out = Array(k=val.length);
-		while (k--) out[k] = (tmp=val[k]) && typeof tmp === 'object' ? klona(tmp) : tmp;
+		out = Array(k = val.length);
+		while (k--) out[k] = (tmp = val[k]) && typeof tmp === 'object' ? klona(tmp) : tmp;
 		return out;
 	}
 
@@ -18,7 +18,7 @@ export function klona(val) {
 					writable: true,
 				});
 			} else {
-				out[k] = (tmp=val[k]) && typeof tmp === 'object' ? klona(tmp) : tmp;
+				out[k] = (tmp = val[k]) && typeof tmp === 'object' ? klona(tmp) : tmp;
 			}
 		}
 		return out;

--- a/src/lite.js
+++ b/src/lite.js
@@ -1,13 +1,13 @@
 export function klona(x) {
 	if (typeof x !== 'object') return x;
 
-	var k, tmp, str=Object.prototype.toString.call(x);
+	var k, tmp, str = Object.prototype.toString.call(x);
 
 	if (str === '[object Object]') {
 		if (x.constructor !== Object && typeof x.constructor === 'function') {
 			tmp = new x.constructor();
 			for (k in x) {
-				if (tmp.hasOwnProperty(k) && tmp[k] !== x[k]) {
+				if (tmp[k] !== x[k]) {
 					tmp[k] = klona(x[k]);
 				}
 			}
@@ -31,7 +31,7 @@ export function klona(x) {
 
 	if (str === '[object Array]') {
 		k = x.length;
-		for (tmp=Array(k); k--;) {
+		for (tmp = Array(k); k--;) {
 			tmp[k] = klona(x[k]);
 		}
 		return tmp;

--- a/test/suites/class.js
+++ b/test/suites/class.js
@@ -1,11 +1,11 @@
-import { suite } from 'uvu';
 import * as assert from 'assert';
+import { suite } from 'uvu';
 
 export default function (klona) {
-	const  Classes = suite('class');
+	const Classes = suite('class');
 
 	Classes('class', () => {
-		class Foobar {}
+		class Foobar { }
 		const input = new Foobar();
 		const output = klona(input);
 
@@ -20,7 +20,7 @@ export default function (klona) {
 
 	// @see https://github.com/lukeed/klona/issues/14
 	Classes('prototype', () => {
-		function Test () {}
+		function Test() { }
 		Test.prototype.val = 42;
 
 		const input = new Test();
@@ -35,7 +35,7 @@ export default function (klona) {
 	});
 
 	Classes('prototype methods :: manual', () => {
-		function Test() {}
+		function Test() { }
 
 		Test.prototype = {
 			count: 0,
@@ -94,7 +94,7 @@ export default function (klona) {
 	});
 
 	Classes('constructor properties', () => {
-		function Test (num) {
+		function Test(num) {
 			this.value = num;
 		}
 
@@ -201,6 +201,20 @@ export default function (klona) {
 			Object.getOwnPropertyDescriptors(input),
 			Object.getOwnPropertyDescriptors(output),
 		);
+	});
+
+	Classes('class assign', () => {
+		class Foobar {
+			constructor(data = undefined) {
+				Object.assign(this, data);
+			}
+		}
+		const input = new Foobar({ test: 123 });
+		const output = klona(input);
+
+		assert.deepEqual(input, output);
+		assert.equal(input.constructor, output.constructor);
+		assert.equal(output.constructor.name, 'Foobar');
 	});
 
 	Classes.run();


### PR DESCRIPTION
When we clone a class that uses Object.assign the cloning result is different. This PR fixes it by removing the hasOwnProperty check.

See https://github.com/lukeed/klona/issues/30#issuecomment-908270498 and https://github.com/lukeed/klona/issues/30#issuecomment-919723976

