### PR TITLE
Circular references, flcone and build improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [8, 10, 12]
+        nodejs: [8, 10, 12, 14, 16, 18]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /json
 /lite
 /full
+/circular

--- a/bench/fixtures/circular.js
+++ b/bench/fixtures/circular.js
@@ -1,0 +1,5 @@
+const full = require("./full");
+
+full.full = full;
+
+module.exports = full;

--- a/bench/index.js
+++ b/bench/index.js
@@ -15,6 +15,10 @@ console.time('clone');
 const clone = require('clone');
 console.timeEnd('clone');
 
+console.time('fclone');
+const fclone = require('fclone');
+console.timeEnd('fclone');
+
 console.time('clone-deep');
 const clonedeep = require('clone-deep');
 console.timeEnd('clone-deep');
@@ -38,6 +42,10 @@ console.timeEnd('klona/lite');
 console.time('klona/json');
 const json = require('klona/json');
 console.timeEnd('klona/json');
+
+console.time('klona/circular');
+const circular = require('klona/circular');
+console.timeEnd('klona/circular');
 
 const naiive = x => JSON.parse(JSON.stringify(x));
 const clone_full = x => clone(x, { includeNonEnumerable: true });
@@ -84,35 +92,51 @@ runner('json', {
 	'rfdc': rfdc(),
 	'clone': clone,
 	'clone/include': clone_full,
+	'fclone': fclone,
 	'clone-deep': clonedeep,
 	'deep-copy': deepcopy,
 	'klona/full': full.klona,
 	'klona': klona.klona,
 	'klona/lite': lite.klona,
 	'klona/json': json.klona,
+	'klona/circular': circular.klona,
 });
 
 runner('lite', {
 	'lodash': lodash,
 	'clone': clone,
 	'clone/include': clone_full,
+	'fclone': fclone,
 	'clone-deep': clonedeep,
 	'klona/full': full.klona,
 	'klona': klona.klona,
 	'klona/lite': lite.klona,
+	'klona/circular': circular.klona,
 });
 
 runner('default', {
 	'lodash': lodash, // FAIL @ Buffer, Map keys
 	'clone': clone, // FAIL @ DataView
 	'clone/include': clone_full, // FAIL @ DataView
+	'fclone': fclone,
 	// FAIL @ "Set #2" & "Map #2" :: 'clone-deep': clonedeep,
 	'klona/full': full.klona,
 	'klona': klona.klona,
+	'klona/circular': circular.klona,
 });
 
 runner('full', {
 	'lodash': lodash, // FAIL @ Buffer, Map keys, non-enumerable properties,
 	'clone/include': clone_full, // FAIL @ DataView, non-enumerable descriptors
+	'fclone': fclone,
 	'klona/full': full.klona,
+	'klona/circular': circular.klona,
+});
+
+runner('circular', {
+	'lodash': lodash, 
+	'clone/include': clone_full, // FAIL @ DataView, non-enumerable descriptors
+	'fclone': fclone,
+	'klona/full': full.klona,
+	'klona/circular': circular.klona,
 });

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "start": "node index.js"
+  },
   "devDependencies": {
     "benchmark": "2.1.4",
     "clone": "2.1.2",
@@ -8,6 +11,7 @@
     "deepcopy": "2.0.0",
     "klona": "file:../",
     "lodash": "4.17.19",
-    "rfdc": "1.1.4"
+    "rfdc": "1.1.4",
+    "fclone": "^1.0.11"
   }
 }

--- a/bench/validate/circular.js
+++ b/bench/validate/circular.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+
+module.exports = function (_, copy) {
+	assert.ok(["[object Circular]", "[Circular]"].includes(copy.full));
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dist",
     "full",
     "json",
+    "circular",
     "lite"
   ],
   "exports": {
@@ -37,22 +38,39 @@
       "import": "./full/index.mjs",
       "require": "./full/index.js"
     },
+    "./circular": {
+      "import": "./circular/index.mjs",
+      "require": "./circular/index.js"
+    },
     "./package.json": "./package.json"
   },
   "modes": {
     "json": "src/json.js",
     "lite": "src/lite.js",
     "default": "src/index.js",
-    "full": "src/full.js"
+    "full": "src/full.js",
+    "circular": "src/circular.js"
   },
   "engines": {
     "node": ">= 8"
   },
   "scripts": {
-    "build": "bundt",
+    "build": "pnpm clear && bundt && pnpm postbuild",
     "pretest": "npm run build",
-    "postbuild": "echo \"lite full json\" | xargs -n1 cp -v index.d.ts",
-    "test": "uvu -r esm test -i suites"
+    "postbuild": "echo \"dist lite full json circular\" | xargs -n1 cp -v index.d.ts",
+    "test": "uvu -r esm test -i suites",
+    "clear": "rm -rf dist full json lite circular",
+    "build2": "pnpm clear && pnpm run-p build2:* && pnpm postbuild",
+    "build2:json-esm": "esbuild --minify --format=esm --platform=neutral --outfile=json/index.mjs src/json.js",
+    "build2:json-cjs": "esbuild --minify --format=cjs --platform=neutral --outfile=json/index.js src/json.js",
+    "build2:lite-esm": "esbuild --minify --format=esm --platform=neutral --outfile=lite/index.mjs src/lite.js",
+    "build2:lite-cjs": "esbuild --minify --format=cjs --platform=neutral --outfile=lite/index.js src/lite.js",
+    "build2:dflt-esm": "esbuild --minify --format=esm --platform=neutral --outfile=dist/index.mjs src/index.js",
+    "build2:dflt-cjs": "esbuild --minify --format=cjs --platform=neutral --outfile=dist/index.js src/index.js",
+    "build2:full-esm": "esbuild --minify --format=esm --platform=neutral --outfile=full/index.mjs src/full.js",
+    "build2:full-cjs": "esbuild --minify --format=cjs --platform=neutral --outfile=full/index.js src/full.js",
+    "build2:circ-esm": "esbuild --minify --format=esm --platform=neutral --outfile=circular/index.mjs src/circular.js",
+    "build2:circ-cjs": "esbuild --minify --format=cjs --platform=neutral --outfile=circular/index.js src/circular.js"
   },
   "keywords": [
     "clone",
@@ -64,7 +82,9 @@
   ],
   "devDependencies": {
     "bundt": "1.0.2",
+    "esbuild": "^0.14.46",
     "esm": "3.2.25",
+    "npm-run-all": "^4.1.5",
     "uvu": "0.5.2"
   }
 }

--- a/src/circular.js
+++ b/src/circular.js
@@ -1,0 +1,71 @@
+function set(obj, key, val, opt) {
+	if (typeof val.value === 'object') val.value = klona(val.value, opt);
+	if (!val.enumerable || val.get || val.set || !val.configurable || !val.writable || key === '__proto__') {
+		Object.defineProperty(obj, key, val);
+	} else obj[key] = val.value;
+}
+
+const baseOptions = {
+	seen: new Set()
+}
+
+/**
+ * Clone any object deep without caring about circular references again.
+ * 
+ * If you want to manually improve memory performance add the seen Set option 
+ * yourself and clear it after the clone.
+ * 
+ * @param {Object} x - object to clone
+ * @param {{ seen: Set }} opt - options
+ * 
+ * @returns your object, but cloned
+ */
+export function klona(x, opt = baseOptions) {
+	if (typeof x !== 'object') return x;
+
+	var i=0, k, list, tmp, str=Object.prototype.toString.call(x);
+	opt.seen.add(x);
+
+	if (str === '[object Object]') {
+		tmp = Object.create(x.__proto__ || null);
+	} else if (str === '[object Array]') {
+		tmp = Array(x.length);
+	} else if (str === '[object Set]') {
+		tmp = new Set;
+		x.forEach(function (val) {
+			tmp.add(klona(val, opt));
+		});
+	} else if (str === '[object Map]') {
+		tmp = new Map;
+		x.forEach(function (val, key) {
+			tmp.set(klona(key, opt), klona(val, opt));
+		});
+	} else if (str === '[object Date]') {
+		tmp = new Date(+x);
+	} else if (str === '[object RegExp]') {
+		tmp = new RegExp(x.source, x.flags);
+	} else if (str === '[object DataView]') {
+		tmp = new x.constructor( klona(x.buffer, opt) );
+	} else if (str === '[object ArrayBuffer]') {
+		tmp = x.slice(0);
+	} else if (str.slice(-6) === 'Array]') {
+		tmp = x.constructor.from(x);
+	}
+
+	if (tmp) {
+		for (list=Object.getOwnPropertySymbols(x); i < list.length; i++) {
+			set(tmp, list[i], Object.getOwnPropertyDescriptor(x, list[i]), opt);
+		}
+
+		for (i=0, list=Object.getOwnPropertyNames(x); i < list.length; i++) {
+			if (Object.hasOwnProperty.call(tmp, k=list[i]) && tmp[k] === x[k]) continue;
+			if (opt.seen.has(x[k])) {
+				tmp[k] = "[object Circular]";
+			} else {
+				set(tmp, k, Object.getOwnPropertyDescriptor(x, k), opt);
+			}
+		}
+	}
+
+	return tmp || x;
+}

--- a/test/circular.js
+++ b/test/circular.js
@@ -1,0 +1,29 @@
+import * as suites from './suites';
+import { klona } from '../src/circular';
+
+suites.API(klona);
+
+suites.Strings(klona);
+suites.Booleans(klona);
+suites.Numbers(klona);
+suites.Nully(klona);
+
+suites.Dates(klona);
+suites.RegExps(klona);
+
+suites.Objects(klona);
+suites.Arrays(klona);
+
+suites.Functions(klona);
+suites.Pollutions(klona);
+suites.Classes(klona);
+
+suites.Maps(klona);
+suites.Sets(klona);
+
+suites.TypedArrays(klona);
+
+suites.Symbols(klona);
+suites.Descriptors(klona);
+suites.Dicts(klona);
+suites.Circular(klona);

--- a/test/suites/circular.js
+++ b/test/suites/circular.js
@@ -1,0 +1,19 @@
+import { suite } from 'uvu';
+import * as assert from 'assert';
+
+export default function (klona) {
+	const Circular = suite('Map');
+
+	Circular('base', () => {
+		const input = { a: 1 };
+		input.input = input;
+		const output = klona(input);
+
+		output.hello = "world"
+		assert.equal(input.hello, undefined);
+
+		assert.equal(output.input, "[object Circular]");
+	});
+
+	Circular.run();
+}

--- a/test/suites/index.js
+++ b/test/suites/index.js
@@ -22,3 +22,4 @@ export { default as Arrays } from './array';
 export { default as Functions } from './function';
 export { default as Pollutions } from './pollution';
 export { default as Classes } from './class';
+export { default as Circular } from './circular';

--- a/test/suites/typedarray.js
+++ b/test/suites/typedarray.js
@@ -67,7 +67,7 @@ export default function(klona) {
 		assert.equal(output[0], 0);
 	});
 
-	test('ArrayBuffer :: empty', () => {
+	test('ArrayBuffer :: empty', () => {
 		const input = new ArrayBuffer(6);
 		const output = klona(input);
 
@@ -85,7 +85,7 @@ export default function(klona) {
 		assert.equal(view2.getInt8(1), 8);
 	});
 
-	test('ArrayBuffer :: values', () => {
+	test('ArrayBuffer :: values', () => {
 		const input = new ArrayBuffer(3);
 		const view1 = new DataView(input);
 


### PR DESCRIPTION
Since I know you think this is out of scope maybe you are anyway interested in.

- Added circular.js file which kinda mimics the lodash behaviour
- Added flcone in bench table (I wanted to compare that one)
- Use "esbuild" to build for smaller builds

I also noticed that your gzip numbers aren't right. Seems bundlt does not calculate them correctly.

> Everything ron on a: iMac21,2 macOS 12.4 arm64 in zsh

Closes: #37 