### PR TITLE
Add types to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,22 +22,22 @@
   ],
   "exports": {
     ".": {
-      "types": "./types.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./json": {
-      "types": "./types.d.ts",
+      "types": "./index.d.ts",
       "import": "./json/index.mjs",
       "require": "./json/index.js"
     },
     "./lite": {
-      "types": "./types.d.ts",
+      "types": "./index.d.ts",
       "import": "./lite/index.mjs",
       "require": "./lite/index.js"
     },
     "./full": {
-      "types": "./types.d.ts",
+      "types": "./index.d.ts",
       "import": "./full/index.mjs",
       "require": "./full/index.js"
     },

--- a/package.json
+++ b/package.json
@@ -22,18 +22,22 @@
   ],
   "exports": {
     ".": {
+      "types": "./types.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./json": {
+      "types": "./types.d.ts",
       "import": "./json/index.mjs",
       "require": "./json/index.js"
     },
     "./lite": {
+      "types": "./types.d.ts",
       "import": "./lite/index.mjs",
       "require": "./lite/index.js"
     },
     "./full": {
+      "types": "./types.d.ts",
       "import": "./full/index.mjs",
       "require": "./full/index.js"
     },


### PR DESCRIPTION
Without this, newer TS module resolution modes point out that there aren't types for these export mappings:

```
src/schema.test.ts:1:23 - error TS7016: Could not find a declaration file for module 'klona'. '/home/jabaile/work/python/pyright-action/node_modules/klona/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/home/jabaile/work/python/pyright-action/node_modules/klona/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'klona' library may need to update its package.json or typings.

1 import { klona } from "klona";
```